### PR TITLE
Added help for onPremiseServerUrl

### DIFF
--- a/src/main/java/com/smartbear/jenkins/plugins/testcomplete/TcTestBuilder.java
+++ b/src/main/java/com/smartbear/jenkins/plugins/testcomplete/TcTestBuilder.java
@@ -1369,6 +1369,10 @@ public class TcTestBuilder extends Builder implements Serializable, SimpleBuildS
         }
 
         if (DEBUG) {
+            TcLog.debug(listener, Messages.TcTestBuilder_Debug_OnPremiseServerUrl(), onPremiseServerUrl);
+        }
+
+        if (DEBUG) {
             TcLog.debug(listener, Messages.TcTestBuilder_Debug_AdditionalCommandLineArguments(), commandLineArguments);
         }
 

--- a/src/main/resources/com/smartbear/jenkins/plugins/testcomplete/Messages.properties
+++ b/src/main/resources/com/smartbear/jenkins/plugins/testcomplete/Messages.properties
@@ -20,6 +20,7 @@ TcTestBuilder.Debug.FixedExitCodeMessage = Original exit code: %s. Fixed exit co
 TcTestBuilder.Debug.ExitCodeReadFailed = Failed to read test runner exit code from file.
 TcTestBuilder.Debug.ExitCodeRead = Test runner exit code read from file: %s.
 TcTestBuilder.Debug.ExitCodeFileNotExists = Test runner exit code file not exists.
+TcTestBuilder.Debug.OnPremiseServerUrl = On Premise Server Url: %s.
 TcTestBuilder.Debug.AdditionalCommandLineArguments = Additional command line arguments: %s.
 TcTestBuilder.Debug.SessionScreenResolution = Session screen resolution : %s.
 TcTestBuilder.Debug.FailedToDefineSelfVersion = Failed to define plugin version.

--- a/src/main/webapp/help/TcTestBuilder/onPremiseServerUrl.html
+++ b/src/main/webapp/help/TcTestBuilder/onPremiseServerUrl.html
@@ -1,0 +1,3 @@
+<div>
+    <p>URL of the Smartbear On-Premise License Manager</p>
+</div>


### PR DESCRIPTION
Now user is able to set the on-premise server URL argument by default without using CommandLineArguments box.

https://smartbear.atlassian.net/browse/TC-105461

A continuation of https://github.com/SmartBear/testcomplete-plugin/pull/2